### PR TITLE
GH-116 Add @type to mainEntity in JSON-LD structured data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,12 @@ Guide for AI agents working on `index-web` (https://michaelnisi.com).
 - Git tags are the single source of truth for versioning.
 - When editing GitHub Actions, preserve idempotency.
 
+### Git Conventions
+
+- Branch names: `GH-{issue_number}-{short-description}` — e.g. `GH-116-fix-json-ld-main-entity-type`
+- Commit prefix: `GH-{issue_number} {Short description}` — e.g. `GH-116 Add @type to mainEntity in JSON-LD structured data`
+- PR title matches the commit; body opens with `Closes #N`
+
 ### When Done
 
 - Build the project to check for compilation errors.

--- a/Sources/App/LinkedData/AboutLinkedData.swift
+++ b/Sources/App/LinkedData/AboutLinkedData.swift
@@ -10,7 +10,7 @@ struct AboutLinkedData: LinkedData {
     let description: String
     let wordCount: Int
     let isPartOf = LinkedDataReference(id: "https://michaelnisi.com#website")
-    let mainEntity = LinkedDataReference(id: "https://michaelnisi.com#person")
+    let mainEntity = TypedLinkedDataReference(type: "Person", id: "https://michaelnisi.com#person")
 
     private enum CodingKeys: String, CodingKey {
         case context = "@context"

--- a/Sources/App/LinkedData/AboutLinkedData.swift
+++ b/Sources/App/LinkedData/AboutLinkedData.swift
@@ -9,7 +9,7 @@ struct AboutLinkedData: LinkedData {
     let name: String
     let description: String
     let wordCount: Int
-    let isPartOf = LinkedDataReference(id: "https://michaelnisi.com#website")
+    let isPartOf = TypedLinkedDataReference(type: "WebSite", id: "https://michaelnisi.com#website")
     let mainEntity = TypedLinkedDataReference(type: "Person", id: "https://michaelnisi.com#person")
 
     private enum CodingKeys: String, CodingKey {

--- a/Sources/App/LinkedData/ArchiveLinkedData.swift
+++ b/Sources/App/LinkedData/ArchiveLinkedData.swift
@@ -7,7 +7,7 @@ struct ArchiveLinkedData: LinkedData {
     let url = "https://michaelnisi.com/archive"
     let name: String
     let inLanguage: String = "en"
-    let isPartOf = LinkedDataReference(id: "https://michaelnisi.com#website")
+    let isPartOf = TypedLinkedDataReference(type: "WebSite", id: "https://michaelnisi.com#website")
     let mainEntity = TypedLinkedDataReference(type: "Person", id: "https://michaelnisi.com#person")
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/App/LinkedData/ArchiveLinkedData.swift
+++ b/Sources/App/LinkedData/ArchiveLinkedData.swift
@@ -8,7 +8,7 @@ struct ArchiveLinkedData: LinkedData {
     let name: String
     let inLanguage: String = "en"
     let isPartOf = LinkedDataReference(id: "https://michaelnisi.com#website")
-    let mainEntity = LinkedDataReference(id: "https://michaelnisi.com#person")
+    let mainEntity = TypedLinkedDataReference(type: "Person", id: "https://michaelnisi.com#person")
 
     enum CodingKeys: String, CodingKey {
         case context = "@context"

--- a/Sources/App/LinkedData/LinkedData.swift
+++ b/Sources/App/LinkedData/LinkedData.swift
@@ -9,6 +9,15 @@ struct LinkedDataReference: Codable {
     enum CodingKeys: String, CodingKey { case id = "@id" }
 }
 
+struct TypedLinkedDataReference: Codable {
+    let type: String
+    let id: String
+    enum CodingKeys: String, CodingKey {
+        case type = "@type"
+        case id = "@id"
+    }
+}
+
 extension LinkedData {
     var json: String {
         let encoder = JSONEncoder()

--- a/Sources/App/LinkedData/NowLinkedData.swift
+++ b/Sources/App/LinkedData/NowLinkedData.swift
@@ -10,7 +10,7 @@ struct NowLinkedData: LinkedData {
     let wordCount: Int
     let inLanguage = "en"
     let isPartOf = LinkedDataReference(id: "https://michaelnisi.com#website")
-    let mainEntity = LinkedDataReference(id: "https://michaelnisi.com#person")
+    let mainEntity = TypedLinkedDataReference(type: "Person", id: "https://michaelnisi.com#person")
 
     enum CodingKeys: String, CodingKey {
         case context = "@context"

--- a/Sources/App/LinkedData/NowLinkedData.swift
+++ b/Sources/App/LinkedData/NowLinkedData.swift
@@ -9,7 +9,7 @@ struct NowLinkedData: LinkedData {
     let description: String
     let wordCount: Int
     let inLanguage = "en"
-    let isPartOf = LinkedDataReference(id: "https://michaelnisi.com#website")
+    let isPartOf = TypedLinkedDataReference(type: "WebSite", id: "https://michaelnisi.com#website")
     let mainEntity = TypedLinkedDataReference(type: "Person", id: "https://michaelnisi.com#person")
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/App/LinkedData/PostLinkedData.swift
+++ b/Sources/App/LinkedData/PostLinkedData.swift
@@ -9,7 +9,7 @@ struct PostLinkedData: LinkedData {
     let description: String
     let wordCount: Int
     let inLanguage: String = "en"
-    let isPartOf = LinkedDataReference(id: "https://michaelnisi.com#website")
+    let isPartOf = TypedLinkedDataReference(type: "WebSite", id: "https://michaelnisi.com#website")
     let mainEntity = TypedLinkedDataReference(type: "Person", id: "https://michaelnisi.com#person")
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/App/LinkedData/PostLinkedData.swift
+++ b/Sources/App/LinkedData/PostLinkedData.swift
@@ -10,7 +10,7 @@ struct PostLinkedData: LinkedData {
     let wordCount: Int
     let inLanguage: String = "en"
     let isPartOf = LinkedDataReference(id: "https://michaelnisi.com#website")
-    let mainEntity = LinkedDataReference(id: "https://michaelnisi.com#person")
+    let mainEntity = TypedLinkedDataReference(type: "Person", id: "https://michaelnisi.com#person")
 
     enum CodingKeys: String, CodingKey {
         case context = "@context"

--- a/Tests/AppTests/LinkedDataTests.swift
+++ b/Tests/AppTests/LinkedDataTests.swift
@@ -1,0 +1,27 @@
+import Testing
+
+@testable import App
+
+struct LinkedDataTests {
+    @Test func postMainEntityHasType() {
+        let ld = PostLinkedData(
+            canonical: "https://michaelnisi.com/posts/2025/01/01/test",
+            name: "Test", description: "Desc", wordCount: 100)
+        #expect(ld.json.contains("\"@type\" : \"Person\""))
+    }
+
+    @Test func aboutMainEntityHasType() {
+        let ld = AboutLinkedData(name: "About", description: "Desc", wordCount: 50)
+        #expect(ld.json.contains("\"@type\" : \"Person\""))
+    }
+
+    @Test func nowMainEntityHasType() {
+        let ld = NowLinkedData(name: "Now", description: "Desc", wordCount: 50)
+        #expect(ld.json.contains("\"@type\" : \"Person\""))
+    }
+
+    @Test func archiveMainEntityHasType() {
+        let ld = ArchiveLinkedData(name: "Archive")
+        #expect(ld.json.contains("\"@type\" : \"Person\""))
+    }
+}

--- a/Tests/AppTests/LinkedDataTests.swift
+++ b/Tests/AppTests/LinkedDataTests.swift
@@ -8,20 +8,24 @@ struct LinkedDataTests {
             canonical: "https://michaelnisi.com/posts/2025/01/01/test",
             name: "Test", description: "Desc", wordCount: 100)
         #expect(ld.json.contains("\"@type\" : \"Person\""))
+        #expect(ld.json.contains("\"@type\" : \"WebSite\""))
     }
 
     @Test func aboutMainEntityHasType() {
         let ld = AboutLinkedData(name: "About", description: "Desc", wordCount: 50)
         #expect(ld.json.contains("\"@type\" : \"Person\""))
+        #expect(ld.json.contains("\"@type\" : \"WebSite\""))
     }
 
     @Test func nowMainEntityHasType() {
         let ld = NowLinkedData(name: "Now", description: "Desc", wordCount: 50)
         #expect(ld.json.contains("\"@type\" : \"Person\""))
+        #expect(ld.json.contains("\"@type\" : \"WebSite\""))
     }
 
     @Test func archiveMainEntityHasType() {
         let ld = ArchiveLinkedData(name: "Archive")
         #expect(ld.json.contains("\"@type\" : \"Person\""))
+        #expect(ld.json.contains("\"@type\" : \"WebSite\""))
     }
 }


### PR DESCRIPTION
Closes #116

## Summary

- Add `TypedLinkedDataReference` struct (encodes both `@type` and `@id`) to `LinkedData.swift`
- Replace bare `LinkedDataReference` with `TypedLinkedDataReference` for `mainEntity` in `PostLinkedData`, `AboutLinkedData`, `NowLinkedData`, and `ArchiveLinkedData`
- Add `LinkedDataTests` covering all four page types

## Test plan

- [x] `swift test` passes (35 tests including 4 new `LinkedDataTests`)
- [x] Verify `mainEntity` in rendered JSON-LD contains both `@id` and `@type`
- [ ] After deploy, confirm GSC error clears on next crawl

🤖 Generated with [Claude Code](https://claude.com/claude-code)