### PR TITLE
GH-120 Clarify why ETagVaryMiddleware coexists with ensureVaryAcceptEncoding

### DIFF
--- a/Sources/App/Application+build.swift
+++ b/Sources/App/Application+build.swift
@@ -42,6 +42,9 @@ private func buildRouter(logger: Logger) async throws -> Router<AppRequestContex
         LogRequestsMiddleware(logger.logLevel)
         RequestDecompressionMiddleware()
         FileMiddleware(cacheControl: .allMediaTypes(maxAge: 86400), logger: logger)
+        // Adds Vary: Accept-Encoding to ETag responses from FileMiddleware, which builds
+        // its own responses outside of Response+ETag. HTML and feed responses handle
+        // this themselves via ensureVaryAcceptEncoding.
         ETagVaryMiddleware()
         ResponseCompressionMiddleware(minimumResponseSizeToCompress: 512)
         HeadMiddleware()


### PR DESCRIPTION
Closes #120

Adds a comment at the `ETagVaryMiddleware` call-site in `Application+build.swift` explaining that the split with `ensureVaryAcceptEncoding` in `Response+ETag` is intentional — each covers a different response path (`FileMiddleware` vs. HTML/feed handlers).